### PR TITLE
fix: create possible number font only once

### DIFF
--- a/boardClass.lua
+++ b/boardClass.lua
@@ -137,8 +137,7 @@ end
 
 
 function drawPossibleNumbersForSmallBox(x,y,width,height, boardData,index)
-  local originalSystemFont = gfx.getSystemFont()
-  -- local possibleNumberFont = gfx.font.new("font-Bitmore")
+  local originalSystemFont = gfx.getSystemFont() 
   gfx.setFont(possibleNumberFont)
   local x1,x2,x3 = x+width*(1/6), x+width*(3/6), x+width*(5/6)
   local y1,y2, y3 = y+height*(1/12), y+height*(5/12), y+height*(9/12)
@@ -255,7 +254,6 @@ function showPossibleNumberSelector(boardData,board)
             gfx.drawLine(x,y+height*(2/3),x+width,y+height*(2/3))
             local originalSystemFont = gfx.getSystemFont()
             print(originalSystemFont)
-            -- local possibleNumberFont = gfx.font.new("font-Bitmore")
             gfx.setFont(possibleNumberFont)
             print(gfx.getSystemFont())
             if boardData.selected.possible[1] then

--- a/boardClass.lua
+++ b/boardClass.lua
@@ -4,6 +4,7 @@ import "CoreLibs/sprites"
 import "CoreLibs/timer"
 
 local gfx <const> = playdate.graphics
+local possibleNumberFont = gfx.font.new("font-Bitmore")
 
 status = {
     ["Given"] = 1,
@@ -137,7 +138,7 @@ end
 
 function drawPossibleNumbersForSmallBox(x,y,width,height, boardData,index)
   local originalSystemFont = gfx.getSystemFont()
-  local possibleNumberFont = gfx.font.new("font-Bitmore")
+  -- local possibleNumberFont = gfx.font.new("font-Bitmore")
   gfx.setFont(possibleNumberFont)
   local x1,x2,x3 = x+width*(1/6), x+width*(3/6), x+width*(5/6)
   local y1,y2, y3 = y+height*(1/12), y+height*(5/12), y+height*(9/12)
@@ -254,7 +255,7 @@ function showPossibleNumberSelector(boardData,board)
             gfx.drawLine(x,y+height*(2/3),x+width,y+height*(2/3))
             local originalSystemFont = gfx.getSystemFont()
             print(originalSystemFont)
-            local possibleNumberFont = gfx.font.new("font-Bitmore")
+            -- local possibleNumberFont = gfx.font.new("font-Bitmore")
             gfx.setFont(possibleNumberFont)
             print(gfx.getSystemFont())
             if boardData.selected.possible[1] then

--- a/pdxinfo
+++ b/pdxinfo
@@ -2,6 +2,6 @@ name=Sudoku
 author=Matthew Leiman
 description=A simple sudoku game with around 400,000 puzzles broken up into 4 difficulties.
 bundleID=co.leiman.playdate_sudoku
-version=.3
+version=.3.1
 imagePath=card
 launchSoundPath=launchImage


### PR DESCRIPTION
With this patch `possibleNumberFont` object created only once, and reused when needed.
For me personally this helped w/ lags on device in the most recent version

thanks for the cool game! =^__^=